### PR TITLE
참가신청 버튼 추가 및 alert 내용 변경

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,11 @@
           <p>
             오픈소스 + 커뮤니티 + 데이터사용자<br /> 2017.10.13
           </p>
+            <ul class="actions">
+                <li><a href="void(0);"
+                       onclick="alert('더 알찬 행사를 위해 22일 티켓팅이 시작됩니다. 혼선을 드려 죄송합니다.');return false;"
+                       class="button">데이터야놀자 참가 신청</a></li>
+            </ul>
         </header>
         <span class="image"><img src="images/pic01.jpg" alt="" /></span>
       </div>
@@ -127,7 +132,7 @@
                 <li>09/10 엔젤 묻지마 후원사 확정</li>
                 <li>09/10 언론사 기사 회견 (불발)</li>
                 <li>09/10 오거나이저 놀음꾼 2차 모임 - 양재 시민의 숲</li>
-                <li>09/15 얼리버드 티켓 판매 연사 및 프로그램 확정</li>
+                <li>09/15 얼리버드 티켓 판매(취소) 연사 및 프로그램 확정</li>
                 <li>09/22 티켓 오픈 & 후원 마감</li>
                 <li>09/23 놀음꾼 & 연사 모임 - 그린팩토리 & 사진 촬영</li>
                 <li>10/13 데이터야놀자 축제 (대관 문제로 미확정)</li>
@@ -166,7 +171,7 @@
 
         <ul class="actions">
           <li><a href="void(0);"
-            onclick="alert('행사장 대관 문제로 9월 15일부터 진행 예정입니다. 혼선을 드려 죄송합니다.');return false;"
+            onclick="alert('더 알찬 행사를 위해 22일 티켓팅이 시작됩니다. 혼선을 드려 죄송합니다.');return false;"
             class="button">데이터야놀자 참가 신청</a></li>
         </ul>
       </div>


### PR DESCRIPTION
얼리버드 티켓 판매 취소결정으로 인한 수정

- 배너에 참가신청버튼 추가
- 일정에 `얼리버드 티켓 판매(취소)` -> `얼리버드 티켓 판매(취소)` 수정
- 참가신청버튼 alert 메시지 수정 -> `더 알찬 행사를 위해 22일 티켓팅이 시작됩니다. 혼선을 드려 죄송합니다.`
